### PR TITLE
fix: do not output error if no key specified; throw if key is invalid

### DIFF
--- a/lib/keypair.js
+++ b/lib/keypair.js
@@ -42,18 +42,24 @@ const RSA_KEY_LENGTH = 4096;
  * @return {module:crx3/lib/createKeyPair.KeyPair}
  */
 function createKeyPair (keyPath = '') {
-	var keyPair = tryLoadKeyPair(keyPath);
-
-	if (keyPair) {
+	if (!keyPath) {
+		console.warn('No `keyPath` was specified. Private key will not be loaded from or saved to a file.');
+	}
+	else if (fs.existsSync(keyPath)) {
+		const keyPair = tryLoadKeyPair(keyPath);
+		if (!keyPair) {
+			throw new Error(`"${keyPath}" already exists but could not be loaded.`);
+		}
 		return keyPair;
 	}
 
-	if (keyPath && fs.existsSync(keyPath)) {
-		console.error(`"${keyPath}" already exists but could not be loaded.`);
-		return null;
+	const keyPair = crypto.generateKeyPairSync('rsa', {modulusLength: RSA_KEY_LENGTH});
+
+	if (keyPath) {
+		trySaveKeyPair(keyPath, keyPair);
 	}
 
-	return createNewKeyPair(keyPath);
+	return keyPair;
 }
 
 /**
@@ -73,39 +79,33 @@ function tryLoadKeyPair (keyPath) {
 		};
 	}
 	catch (e) {
-		console.error(`Could not load key from "${keyPath}"`, e);
-		return null;
+		console.error(`Could not load key from "${keyPath}"`);
+		console.error(e);
 	}
+	return null;
 }
 
 /**
- * Generate new pair of keys and save private key to file.
+ * Try to safely save private key to file.
  *
  * @private
  * @param {string} keyPath
+ * @param {module:crx3/lib/createKeyPair.KeyPair} keyPair
  */
-function createNewKeyPair (keyPath) {
-	const pair = crypto.generateKeyPairSync('rsa', {modulusLength: RSA_KEY_LENGTH});
-	pair.savedFile = null;
+function trySaveKeyPair (keyPath, keyPair) {
+	keyPair.savedFile = null;
 
-	if (!keyPath) {
-		console.warn('No `keyPath` was specified. Private key will not be saved to a file.');
-		return pair;
-	}
-
-	const privateKeyData = pair.privateKey.export({
+	const privateKeyData = keyPair.privateKey.export({
 		type  : 'pkcs8',
 		format: 'pem'
 	});
 
 	try {
 		fs.writeFileSync(keyPath, privateKeyData);
-		pair.savedFile = keyPath;
+		keyPair.savedFile = keyPath;
 	}
 	catch (e) {
 		console.error(`Could not write "${keyPath}" file.`);
 		console.error(e);
 	}
-
-	return pair;
 }

--- a/test/lib/keypair.js
+++ b/test/lib/keypair.js
@@ -47,8 +47,13 @@ test('keypair', t => {
 	const writeOnly = 0o200;
 	fs.writeFileSync(failPath, '', {mode: writeOnly});
 	process.umask(mask);
-	const fail = keypair(failPath);
-	t.strictEqual(fail, null, 'Should return `null` if key file exists but could not be read');
+	t.throws(
+		() => {
+			keypair(failPath);
+		},
+		{message: `"${failPath}" already exists but could not be loaded.`},
+		'Should throw if key file exists but could not be read'
+	);
 	fs.unlinkSync(failPath);
 
 	t.end();


### PR DESCRIPTION
Hello! Thanks for your work. "crx3" is a handy tool that helps me a lot during extension development.

## Why PR

When I package a directory to a ".crx" file, an error message is output:

```console
> crx3 ./dist

Could not load key from "" Error: ENOENT: no such file or directory, open
    at Object.openSync (fs.js:497:3)
    at Object.readFileSync (fs.js:393:35)
    at tryLoadKeyPair (...\node_modules\crx3\lib\keypair.js:68:19)
    at createKeyPair (...\node_modules\crx3\lib\keypair.js:45:16)
    at CRX3Stream.crxInit (...\node_modules\crx3\lib\crx3stream.js:126:19)  
    at CRX3Stream._write (...\node_modules\crx3\lib\crx3stream.js:86:9)     
    at writeOrBuffer (internal/streams/writable.js:358:12)
    at CRX3Stream.Writable.write (internal/streams/writable.js:303:10)
    at PassThrough.ondata (internal/streams/readable.js:731:22)
    at PassThrough.emit (events.js:400:28) {
  errno: -4058,
  syscall: 'open',
  code: 'ENOENT'
}
No `keyPath` was specified. Private key will not be saved to a file.
CRX file created at "...\dist.crx"

```

I don't have a private key to sign my crx files, using the auto-generated one is fine. So, I made some changes and now the output is as follows.

This PR fixes #10 .

## Test result

- No key specified (without `-p ...`):

```console
> crx3 ./dist

No `keyPath` was specified. Private key will not be loaded from or saved to a file.
CRX file created at "...\dist.crx"

```

- Non-existing key specified:

```console
> crx3 ./dist -p "...\non-existing.pem"

Private key file created at "...\non-existing.pem"
CRX file created at "...\dist.crx"

```

- Valid key specified:

```console
> crx3 ./dist -p "...\valid.pem"

CRX file created at "...\dist.crx"

```

- Invalid key specified:

```console
> crx3 ./dist -p "...\empty.pem"

Could not load key from "...\empty.pem"
Error: error:2007E073:BIO routines:BIO_new_mem_buf:null parameter
    at Object.createPrivateKey (internal/crypto/keys.js:351:10)
    at tryLoadKeyPair (...\lib\keypair.js:76:23)
    at createKeyPair (...\lib\keypair.js:49:19)
    at CRX3Stream.crxInit (...\lib\crx3stream.js:126:19)
    at CRX3Stream._write (...\lib\crx3stream.js:86:9)
    at writeOrBuffer (internal/streams/writable.js:358:12)
    at CRX3Stream.Writable.write (internal/streams/writable.js:303:10)
    at PassThrough.ondata (internal/streams/readable.js:731:22)
    at PassThrough.emit (events.js:400:28)
    at addChunk (internal/streams/readable.js:293:12) {
  library: 'BIO routines',
  function: 'BIO_new_mem_buf',
  reason: 'null parameter',
  code: 'ERR_OSSL_BIO_NULL_PARAMETER'
}
...\lib\keypair.js:51
                        throw new Error(`"${keyPath}" already exists but could not be loaded.`);
                        ^

Error: "...\empty.pem" already exists but could not be loaded.
    at createKeyPair (...\lib\keypair.js:51:10)
    at CRX3Stream.crxInit (...\lib\crx3stream.js:126:19)
    at CRX3Stream._write (...\lib\crx3stream.js:86:9)
    at writeOrBuffer (internal/streams/writable.js:358:12)
    at CRX3Stream.Writable.write (internal/streams/writable.js:303:10)
    at PassThrough.ondata (internal/streams/readable.js:731:22)
    at PassThrough.emit (events.js:400:28)
    at addChunk (internal/streams/readable.js:293:12)
    at readableAddChunk (internal/streams/readable.js:267:9)
    at PassThrough.Readable.push (internal/streams/readable.js:206:10)

```

The above error message looks not beautiful, but informative.

https://github.com/ahwayakchih/crx3/blob/55cb0adde7ce2120f60548db1e619ae446fcf99b/lib/crx3stream.js#L125-L135

Here, if `this.crx.keys` is `null`, subsequent calls will fail instantly. Hence, I throw an error instead.

## Environment

Windows 10 22H2.

```console
> ver

Microsoft Windows [Version 10.0.19045.3208]

> node --version     
v14.18.3

> npm --version
6.14.15
```
