### PR TITLE
fix: improved `keyPath`/`keyPair` error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 
 - Updated development dependencies
 - Fixed test runs on Cirrus CI
+- Improved error output when private key cannot be loaded
 
 **v1.1.3** - 2020-11-06
 

--- a/lib/crx3stream.js
+++ b/lib/crx3stream.js
@@ -124,6 +124,13 @@ class CRX3Stream extends WriteStream {
 	 */
 	crxInit (callback) {
 		this.crx.keys = keypair(this.crx.cfg.keyPath);
+
+		if (!this.crx.keys) {
+			this.crx.error = 'CRX3 requires valid private key';
+			callback();
+			return;
+		}
+
 		this.crx.appId = createCrxId(this.crx.keys.publicKey);
 		this.crx.encodedAppId = encodeAppId(this.crx.appId);
 		this.crx.signedHeaderData = createSignedHeaderData(this.crx.appId);

--- a/lib/keypair.js
+++ b/lib/keypair.js
@@ -42,14 +42,18 @@ const RSA_KEY_LENGTH = 4096;
  * @return {module:crx3/lib/createKeyPair.KeyPair}
  */
 function createKeyPair (keyPath = '') {
-	var keyPair = tryLoadKeyPair(keyPath);
-
-	if (keyPair) {
-		return keyPair;
+	if (!keyPath) {
+		return createNewKeyPair(keyPath);
 	}
 
-	if (keyPath && fs.existsSync(keyPath)) {
+	var keyPair = tryLoadKeyPair(keyPath);
+
+	if (keyPair.privateKey && keyPair.publicKey) {
+		return keyPair;
+	}
+	else if (keyPath && fs.existsSync(keyPath)) {
 		console.error(`"${keyPath}" already exists but could not be loaded.`);
+		console.error(keyPair);
 		return null;
 	}
 
@@ -61,7 +65,7 @@ function createKeyPair (keyPath = '') {
  *
  * @private
  * @param {string} keyPath
- * @return {external:crypto.KeyObject|null}
+ * @return {external:crypto.KeyObject|Error}
  */
 function tryLoadKeyPair (keyPath) {
 	try {
@@ -73,8 +77,7 @@ function tryLoadKeyPair (keyPath) {
 		};
 	}
 	catch (e) {
-		console.error(`Could not load key from "${keyPath}"`, e);
-		return null;
+		return e;
 	}
 }
 


### PR DESCRIPTION
As proposed by @pzhlkj6612 in #12:
- do not output error if no key path was specified
- cleaner error output

Unlike in proposal, this change does not change API:
- function names stay the same
- no exceptions are thrown

Example without path to key file:

```sh
> ./bin/crx3.js ./example/example-extension

No `keyPath` was specified. Private key will not be saved to a file.
CRX file created at "/app/example-extension.crx"
```

With path to non-existing key file:

```sh
> ./bin/crx3.js ./example/example-extension -p ./new-key.pem

Private key file created at "/app/new-key.pem"
CRX file created at "/app/example-extension.crx"
```

With path to existing but invalid key file:

```sh
> ./bin/crx3.js ./example/example-extension -p ./invalid-key.pem

"/app/invalid-key.pem" already exists but could not be loaded.
Error: error:1E08010C:DECODER routines::unsupported
    at Object.createPrivateKey (node:internal/crypto/keys:632:12)
    at tryLoadKeyPair (/app/lib/keypair.js:74:23)
    at createKeyPair (/app/lib/keypair.js:49:16)
    at CRX3Stream.crxInit (/app/lib/crx3stream.js:126:19)
    at CRX3Stream._write (/app/lib/crx3stream.js:86:9)
    at doWrite (node:internal/streams/writable:411:12)
    at clearBuffer (node:internal/streams/writable:572:7)
    at CRX3Stream.<anonymous> (node:internal/streams/writable:264:7)
    at Object.onceWrapper (node:events:627:28)
    at CRX3Stream.emit (node:events:513:28) {
  library: 'DECODER routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_UNSUPPORTED'
}
CRX3 requires valid private key
```