### PR TITLE
deps: replace mri with minimist.

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -1,6 +1,6 @@
 const readFileSync = require('fs').readFileSync;
 const path = require('path');
-const mri = require('mri');
+const minimist = require('minimist');
 
 /**
  * @module module:crx3/lib/configuration
@@ -130,7 +130,7 @@ function Configuration () {
  * @return {Configuration} this
  */
 Configuration.prototype.setFromArgv = function setFromArgv () {
-	const argv = mri(process.argv.slice(NUMBER_OF_IGNORED_CLI_ARGS), {
+	const argv = minimist(process.argv.slice(NUMBER_OF_IGNORED_CLI_ARGS), {
 		alias: {
 			crxPath: ['o', 'crx'],
 			zipPath: ['z', 'zip'],

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "crx3": "bin/crx3.js"
   },
   "dependencies": {
-    "mri": "^1.2.0",
+    "minimist": "^1.2.8",
     "pbf": "^3.2.1",
     "yazl": "^2.5.1"
   },


### PR DESCRIPTION
Hi ! mri has a much heavier closure than minimist, for basically the same functionality. This PR replaces one with the other.