### PR TITLE
test: update puppeteer container file, allow disabling sandbox for test

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,20 +187,3 @@ After container image is ready, every time you want to run test, just use:
 ```sh
 podman run --rm --init -v $(pwd):/app -w /app --userns=keep-id -it puppeteer:latest xvfb-run npm test
 ```
-
-### Testing with `docker`
-
-First step is to prepare container image. This step is needed only once.
-
-```sh
-# 1. Prepare container, this step is needed only once
-docker build -t puppeteer -f puppeteer.containerfile
-# 2. Install puppeteer-core, this step is needed only once
-docker run --rm --init -v $(pwd):/app -w /app -it puppeteer:latest npm run puppeteer
-```
-
-After container image is ready, every time you want to run test, just use:
-
-```sh
-docker run --rm --init -v $(pwd):/app -w /app -it puppeteer:latest xvfb-run npm test
-```

--- a/puppeteer.containerfile
+++ b/puppeteer.containerfile
@@ -4,12 +4,24 @@
 #
 FROM docker.io/node:alpine
 
+# If set to values different than the ones used by Node.js (1000:1000 at the time of writing),
+# `node2` group and user will be added and container can be run as that user:
+#   podman run --user node2 -rm -it puppeteer
+ARG UID=
+ARG GID=
+
 USER root
 
-RUN apk add udev gtk+3.0 xorg-server ttf-freefont dbus xvfb xvfb-run chromium\
+RUN apk add udev gtk+3.0 xorg-server ttf-freefont dbus xvfb xvfb-run chromium git\
 	&& mkdir -p /etc/chromium/policies/managed\
 	&& mkdir -p /etc/chromium/policies/recommended\
 	&& chmod -R 777 /etc/chromium/policies
+
+RUN test -n "${UID}" && test "${UID}" != $(id -u node)\
+	&& addgroup -g ${GID} node2\
+	&& adduser -u ${UID} -G node2 -s /bin/bash -D node2\
+	&& cp -a /home/node /home/node2\
+	&& chown -R node2:node2 /home/node2
 
 ENV CHROME_BIN /usr/bin/chromium-browser
 ENV CHROME_POLICIES /etc/chromium/policies

--- a/test/lib/writeCRX3File.js
+++ b/test/lib/writeCRX3File.js
@@ -217,9 +217,11 @@ async function doesItWorkInChrome (t, cfg) {
 
 	const margin = ' '.padStart(t._objectPrintDepth || 0, '.'); // eslint-disable-line no-underscore-dangle
 
-	// Since v112, Chrome/Chromium has "new" headless mode, which supports extensions and does not need XVFB
+	// Since v112, Chrome/Chromium has "new" headless mode, which supports extensions and does not need XVFB.
+	// But there are problems running it by GitHub Actions (inside a rootful container),
+	// so allow to force using "full mode" by setting `CHROME_DISABLE_SANDBOX` in environment.
 	/* eslint-disable array-element-newline, array-bracket-newline, multiline-comment-style */
-	const runFullModeMode = !testVersion(chromeVersion.trim(), '112.0.5614.0');
+	const runFullModeMode = process.env.CHROME_DISABLE_SANDBOX || !testVersion(chromeVersion.trim(), '112.0.5614.0');
 	const browserIgnoreDefaultArgs = [
 		'--disable-extensions', // Do not disable extensions when we want to test them ;P
 		'--disable-background-networking' // Do not prevent browser from force_installing our stuff
@@ -254,7 +256,7 @@ async function doesItWorkInChrome (t, cfg) {
 	/* eslint-enable array-element-newline, array-bracket-newline, multiline-comment-style */
 
 	const browser = await puppeteer.launch({
-		headless         : false, // This has to be false, even when we're passing `headless=new` arg
+		headless         : false, // This has to be false, even when we're passing `headless=new` option
 		executablePath   : process.env.CHROME_BIN || null,
 		ignoreDefaultArgs: browserIgnoreDefaultArgs,
 		args             : browserArgs


### PR DESCRIPTION
Rootful docker is such a drag... a lot of time wasted on trying to run test inside container with GitHub Actions.

Node.js uses default 1000:1000 for "node" user in their container images, but GitHub runs containers as 1001:1001 as described at: https://github.com/actions/toolkit/issues/1889

Matching UID:GID helps with file access/creation problems, but then... Chromium cannot run anyway, because container is run as a "node" user, but GitHub assumes containers are run as a "root" (AFAIK). "Regular" user does not have permissions necessary for Chrome/Chromium to setup sandbox.
When container is run as "root", there are no problems with filesystem, but then Chrome/Chromium panics about running as "root"...

It's quite possible that there is a way to somehow modify user permissions, but i don't have any more time to look for that.

That's why we now:
- build container with additional UID:GID that matches the one used by GitHub Action runners;
- run container as that additional user;
- launch Chromium "the old way", i.e., "full mode" with disabled sandbox and other stuff when running inside container from GitHub Action.

Since it takes a lot of time to test anything in such environment, and i do not use locally Docker any more, i'm dropping example of testing with Docker from the README.