### PR TITLE
feat: add TypeScript type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,100 @@
+/**
+ * TypeScript type definitions for crx3
+ */
+
+import { Readable } from 'stream';
+
+export interface CRX3Options {
+  /**
+   * Name used for files, if they are not specified otherwise.
+   */
+  name?: string;
+  
+  /**
+   * Path name of output CRX file.
+   * @default './web-extension.crx'
+   */
+  crxPath?: string;
+  
+  /**
+   * Optional path name of output ZIP file.
+   * @default ''
+   */
+  zipPath?: string;
+  
+  /**
+   * Private key to be used for signing CRX file.
+   * @default ''
+   */
+  keyPath?: string;
+  
+  /**
+   * Optional path name of output Update Manifest XML file.
+   * @default ''
+   */
+  xmlPath?: string;
+  
+  /**
+   * Optional version name to be written into Update Manifest file.
+   */
+  appVersion?: string;
+  
+  /**
+   * Path to the extension's src directory.
+   */
+  srcPath?: string | string[];
+  
+  /**
+   * If set to true, output will be streamed to stdout.
+   */
+  stdout?: boolean;
+  
+  /**
+   * If set to false, key will not be auto-generated.
+   * @default true
+   */
+  autoKey?: boolean;
+  
+  /**
+   * If set to false, CRX file will not be created.
+   * @default true
+   */
+  crx?: boolean;
+  
+  /**
+   * If set to false, ZIP file will not be created.
+   * @default true
+   */
+  zip?: boolean;
+  
+  /**
+   * If set to false, XML file will not be created.
+   * @default true
+   */
+  xml?: boolean;
+}
+
+/**
+ * Create CRX package from specified files.
+ * 
+ * Private key file will not be created if one already exist. In such case, existing one will be used.
+ * CRX and ZIP files are always overwritten.
+ * 
+ * @param files - Array of file paths or a readable stream
+ * @param options - Configuration options
+ * @returns Promise that resolves when the CRX file is created
+ */
+export default function writeCRX3File(
+  files: string[] | Readable,
+  options?: CRX3Options
+): Promise<void>;
+
+/**
+ * Create CRX package with options only.
+ * 
+ * @param options - Configuration options
+ * @returns Promise that resolves when the CRX file is created
+ */
+export default function writeCRX3File(
+  options: CRX3Options
+): Promise<void>;

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "license": "MIT",
   "files": [
     "bin/**",
+    "index.d.ts",
     "lib/**",
     "index.js",
     "README.md"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "crx3",
   "version": "2.0.0",
+  "types": "index.d.ts",
   "description": "Package web extension into CRX file (version 3) for Google Chrome and Chromium browsers",
   "main": "index.js",
   "homepage": "https://github.com/ahwayakchih/crx3",


### PR DESCRIPTION
This PR adds TypeScript type definitions to crx3.

## Changes
- Added `index.d.ts` with type definitions for the CRX3 package
- Added the `types` field to package.json

## Type Definitions
The type definitions include:
- `CRX3Options` - Configuration options interface with properties like `crxPath`, `zipPath`, `keyPath`, `srcPath`, etc.
- `writeCRX3File` function overloads for creating CRX packages from files or streams

This enables TypeScript users to get proper type hints when using this CRX3 packaging tool.
---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*
---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*